### PR TITLE
The X keyboard layout de_CH does not exist, so replace it with ch: Ge…

### DIFF
--- a/keyboardsetup/keymaps
+++ b/keyboardsetup/keymaps
@@ -100,8 +100,8 @@ se-fi-lat6|se_FI||
 se-ir209|se_SE||
 se-lat6|se_SE||
 sg-latin1-lk450|sg||
-sg-latin1|de_CH||
-sg|de_CH||
+sg-latin1|ch||
+sg|ch||
 sk-prog-qwerty|sk_qwerty||
 sk-prog-qwertz|sk_qwerty||
 sk-prog-qwertz|sk||


### PR DESCRIPTION
…rman (Switzerland)

Setting a layout not listed in /usr/share/X11/xkb/rules/evdev.lst leads to the default (US) layout being actually used. For instance the output of setxkbmap de_CH
is:
Error loading new keyboard description